### PR TITLE
feat(deployment): Implémentation de la limitation des déploiements pa…

### DIFF
--- a/src/app/dashboard/_actions/index.ts
+++ b/src/app/dashboard/_actions/index.ts
@@ -5,6 +5,7 @@ import { yamModule } from '@/server/module/yam.module';
 import { workspaceModule } from '@/server/module/workspace.module';
 import { kube } from '@/server/module/kube.module';
 import { projectModule } from '@/server/module/project.module';
+import prisma from '@/libs/prisma';
 
 interface CreateYamData {
   workspace: string;
@@ -108,6 +109,12 @@ export const deployCodeServerProjectAction = async ({name, namespace, yamId, wor
   if (!user || !userId) {
     return { error: 'No Logged In User' }
   }
+  
+  // Vérifier la limite pour code-server
+  const limitCheck = await checkAppLimit(yamId, 'code-server');
+  if (!limitCheck.canDeploy) {
+    return { error: limitCheck.error };
+  }
 
   try {
     const project = await projectModule.service.create({
@@ -131,12 +138,40 @@ export const deployCodeServerProjectAction = async ({name, namespace, yamId, wor
   }
 }
 
+// Vérifier si une application du même type existe déjà dans le YAM
+const 
+
+
+checkAppLimit = async (yamId: string, appType: string): Promise<{ canDeploy: boolean; error?: string }> => {
+  const existingApps = await prisma.project.count({
+    where: {
+      yamId,
+      type: appType,
+    },
+  });
+
+  // Limite à 1 application du même type par YAM
+  if (existingApps >= 1) {
+    return {
+      canDeploy: false,
+      error: `You have reached the maximum number of deployments for this application (${appType}). Limit: 1`
+    };
+  }
+  return { canDeploy: true };
+};
+
 export const deployWordpressProjectAction = async ({name, namespace, yamId, workspaceId}: DeployProject) => {
   const { userId } = await auth()
   const user = await currentUser()
 
   if (!user || !userId) {
     return { error: 'No Logged In User' }
+  }
+  
+  // Vérifier la limite pour WordPress
+  const limitCheck = await checkAppLimit(yamId, 'wordpress');
+  if (!limitCheck.canDeploy) {
+    return { error: limitCheck.error };
   }
 
   try {
@@ -167,6 +202,12 @@ export const deployN8nProjectAction = async ({name, namespace, yamId, workspaceI
 
   if (!user || !userId) {
     return { error: 'No Logged In User' }
+  }
+  
+  // Vérifier la limite pour n8n
+  const limitCheck = await checkAppLimit(yamId, 'n8n');
+  if (!limitCheck.canDeploy) {
+    return { error: limitCheck.error };
   }
 
   try {

--- a/src/app/dashboard/yams/[workspaceId]/[name]/deploy-project/components/DeployProject.tsx
+++ b/src/app/dashboard/yams/[workspaceId]/[name]/deploy-project/components/DeployProject.tsx
@@ -76,6 +76,11 @@ const DeployProject = ({ expandRightPanel }: Props) => {
         setTimeout(() => {
           router.back()
         }, 5000);
+      } else if (result.error) {
+        // Gérer les erreurs spécifiques comme les limites de déploiement atteintes
+        setShowAnimation(false);
+        console.error("WordPress deployment error:", result.error);
+        errorNotification(result.error);
       }
     } catch (error) {
       setShowAnimation(false);
@@ -103,6 +108,11 @@ const DeployProject = ({ expandRightPanel }: Props) => {
         setTimeout(() => {
           router.back()
         }, 5000);
+      } else if (result.error) {
+        // Gérer les erreurs spécifiques comme les limites de déploiement atteintes
+        setShowAnimation(false);
+        console.error("CodeServer deployment error:", result.error);
+        errorNotification( result.error);
       }
     } catch (error) {
       setShowAnimation(false);
@@ -130,11 +140,15 @@ const DeployProject = ({ expandRightPanel }: Props) => {
         setTimeout(() => {
           router.back()
         }, 5000);
+      } else if (result.error) {
+        // Gérer les erreurs spécifiques comme les limites de déploiement atteintes
+        setShowAnimation(false);
+        console.error("n8n deployment error:", result.error);
+        errorNotification(result.error);
       }
     } catch (error) {
       setShowAnimation(false);
       console.error("Failed to deploy n8n:", error);
-
       errorNotification("Failed to deploy n8n. Please try again.");
     }
   };

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -79,7 +79,7 @@ const Notification: React.FC<NotificationProps> = ({ notification, onClose, ligh
                   {notification.title}
                 </div>
               )}
-              <div className="notification-message ml-8 flex items-center text-right">
+              <div className="notification-message ml-8 flex items-center text-left">
                 {notification.message}
              
             </div>

--- a/src/server/service/project.service.ts
+++ b/src/server/service/project.service.ts
@@ -322,6 +322,18 @@ export const projectService = {
       }
     }
   },
+  // Check if an app of specific type already exists in a YAM
+  checkIfAppTypeExists: async (yamId: string, appType: string): Promise<boolean> => {
+    const existingApp = await prisma.project.findFirst({
+      where: {
+        yamId,
+        type: appType,
+      },
+      select: { id: true },
+    });
+    return !!existingApp;
+  },
+
   // Get app status by checking pods in vCluster
   getStatus: async (projectId: string) => {
     const project = await projectRepository.findById(projectId);


### PR DESCRIPTION
…r type d'application (backend/frontend)

 Ajout d'une fonction utilitaire [checkAppLimit] yamify/src/app/dashboard/_actions/index.ts: pour vérifier les déploiements existants
  - Vérifie le nombre d'applications du même type dans un YAM
  - Limite fixée à 1 application du même type par YAM
  - Retourne un message d'erreur clair en cas de limite atteinte

- Mise à jour des actions de déploiement :
  - WordPress
  - CodeServer
  - n8n
  - Gestion des erreurs spécifiques pour chaque type de déploiement

- Amélioration de l'interface utilisateur :
  - Affichage des messages d'erreur de limitation dans les notifications
  - Arrêt de l'animation de chargement en cas d'erreur
 

- Correction de l'alignement du texte des notifications (aligné à gauche)

Cette fonctionnalité empêche les utilisateurs de déployer plusieurs instances du même type d'application dans un même YAM, avec des retours clairs lorsqu'ils atteignent la limite.
@destino92 