### PR TITLE
 fix(deployment): Correction du nom du déploiement pour code-server

### DIFF
--- a/src/server/module/kube.module.ts
+++ b/src/server/module/kube.module.ts
@@ -258,7 +258,7 @@ persistence:
       '--kubeconfig', kubeconfigPath,
       'rollout',
       'status',
-      'deployment/codeserver',
+      'deployment/codeserver-code-server',
       '--namespace', namespace,
       '--timeout=300s',
     ]);


### PR DESCRIPTION
 -Mise à jour du nom du déploiement de 'codeserver' à 'codeserver-code-server' dans la commande de vérification de statut
- Cette correction résout l'échec du déploiement dû à un nom de déploiement incorrect
- Le nom du déploiement suit maintenant la convention [nom-de-release]-[nom-du-chart] utilisée par Helm
desormais le deploymennt de codeserver fonctionne à nouveau !!!! 
